### PR TITLE
UPSTREAM: Fix projected test to output a new line

### DIFF
--- a/test/e2e/common/projected.go
+++ b/test/e2e/common/projected.go
@@ -1005,7 +1005,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 			{
 				Name:    "projected-all-volume-test",
 				Image:   "gcr.io/google_containers/busybox:1.24",
-				Command: []string{"sh", "-c", "cat /all/podname && cat /all/secret-data && cat /all/configmap-data"},
+				Command: []string{"sh", "-c", "cat /all/podname && cat /all/secret-data && cat /all/configmap-data && echo fix"},
 				VolumeMounts: []v1.VolumeMount{
 					{
 						Name:      "podinfo",


### PR DESCRIPTION
kubectl log doesn't parse a line without a new line.
See https://github.com/kubernetes/kubernetes/issues/44976

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>